### PR TITLE
Fix indexing empty lists and editing list with all operator

### DIFF
--- a/jse/editor.py
+++ b/jse/editor.py
@@ -135,7 +135,7 @@ def edit_func(obj,key,value):
                 return
             obj[int(key)] = value
         except IndexError as err:
-            if len(obj) == 0:
+            if len(obj) == 0 and int(key) == 0:
                 obj.append(value)
                 return
             raise EditorError(f"there is no element with index {key}. The largest index is {len(obj)-1}") from err

--- a/jse/editor.py
+++ b/jse/editor.py
@@ -130,8 +130,8 @@ def edit_func(obj,key,value):
             elif key.lower() in LAST_EXPR:
                key = -1
             elif key.lower() in ALL_EXPR:
-                for k in obj.keys():
-                    obj[k] = value
+                for i in range(len(obj)):
+                    obj[i]= value
                 return
             obj[int(key)] = value
         except IndexError as err:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -349,7 +349,8 @@ def test_star_fails_when_child_not_object():
             assert none_obj == None
             for sub,key in subkeypairs:
                 edit_func(sub,key,"value")
-               
+
+
 def test_edit_empty_list():
     obj = {'root' : [] }
     sub,key = query_object(obj,"root.0")
@@ -361,3 +362,15 @@ def test_edit_empty_list():
         sub,key = query_object(obj,"root.1")
         edit_func(sub,key,"val")
     assert 'index' in str(err)
+
+
+def edit_list_with_ending_star():
+    obj = {'root' : {'a': [1,2,3]}}
+    sub,key = query_object(obj,"root.a.*")
+    edit_func(sub,key,"val")
+    assert obj == {'root' : {'a': ["val","val","val"]}}
+
+    obj = {'root' : {'a': []}}
+    sub,key = query_object(obj,"root.a.*")
+    edit_func(sub,key,"val")
+    assert obj == {'root' : {'a': []}}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -364,7 +364,7 @@ def test_edit_empty_list():
     assert 'index' in str(err)
 
 
-def edit_list_with_ending_star():
+def test_edit_list_with_ending_star():
     obj = {'root' : {'a': [1,2,3]}}
     sub,key = query_object(obj,"root.a.*")
     edit_func(sub,key,"val")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -350,3 +350,14 @@ def test_star_fails_when_child_not_object():
             for sub,key in subkeypairs:
                 edit_func(sub,key,"value")
                
+def test_edit_empty_list():
+    obj = {'root' : [] }
+    sub,key = query_object(obj,"root.0")
+    edit_func(sub,key,"val")
+    assert obj == {'root' : ["val"]}
+
+    obj = {'root' : [] }
+    with pytest.raises(EditorError) as err:
+        sub,key = query_object(obj,"root.1")
+        edit_func(sub,key,"val")
+    assert 'index' in str(err)


### PR DESCRIPTION
these changes fix two bugs:
- using list.1 would work to edit a list with no entires in it, now this causes an index error
- using list.* would not edit that list, now all entries in the list will be set to the value passed.

test cases added for both bugs